### PR TITLE
Calendar Selected Year Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wily-angular-commons",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/modules/date-picker/components/calendar/calendar.component.ts
+++ b/src/app/modules/date-picker/components/calendar/calendar.component.ts
@@ -207,15 +207,17 @@ export class CalendarComponent implements OnDestroy, OnInit {
   readonly validYearRange$: Observable<Array<number>> = this._validSelectionInterval.pipe(
     map(selectionInterval =>
     {
-      CalendarComponent.generateYearRange(
+
+      if (this._selectedYear.getValue() < (selectionInterval?.start as Date)?.getFullYear()) {
+          this._selectedYear.next((selectionInterval?.start as Date)?.getFullYear());
+      }
+      return CalendarComponent.generateYearRange(
         (selectionInterval?.start as Date)?.getFullYear() ?? null,
         (selectionInterval?.end as Date)?.getFullYear() ?? null,
         this.currentDate.year
       );
 
       // check if the _selectedYear is valid in the new date range, if not update to min year of range
-
-
     })
   );
 

--- a/src/app/modules/date-picker/components/calendar/calendar.component.ts
+++ b/src/app/modules/date-picker/components/calendar/calendar.component.ts
@@ -205,11 +205,18 @@ export class CalendarComponent implements OnDestroy, OnInit {
    * The range of selectable years as an Observable
    */
   readonly validYearRange$: Observable<Array<number>> = this._validSelectionInterval.pipe(
-    map(selectionInterval => CalendarComponent.generateYearRange(
-      (selectionInterval?.start as Date)?.getFullYear() ?? null,
-      (selectionInterval?.end as Date)?.getFullYear() ?? null,
-      this.currentDate.year
-    ))
+    map(selectionInterval =>
+    {
+      CalendarComponent.generateYearRange(
+        (selectionInterval?.start as Date)?.getFullYear() ?? null,
+        (selectionInterval?.end as Date)?.getFullYear() ?? null,
+        this.currentDate.year
+      );
+
+      // check if the _selectedYear is valid in the new date range, if not update to min year of range
+
+
+    })
   );
 
   /**


### PR DESCRIPTION
This will fix the issue when using the date range component in transcend angular commons, upon entering valid begin and end dates. When updating the begin date, and clicking on the End Date Date picker, the Year Select is blank.

[Date Range Component Edit](https://app.gitkraken.com/glo/view/card/1285930d906a4494958b70bbab608b45)